### PR TITLE
deep_class_var

### DIFF
--- a/lib/csv_row_model/import.rb
+++ b/lib/csv_row_model/import.rb
@@ -44,9 +44,9 @@ module CsvRowModel
 
     class_methods do
 
-      # @return [Hash] map of `relation_name => CsvRowModel::Import class`
-      def has_many_relationships
-        memoized_class_included_var :has_many_relationships, {}, Import
+      # @return [Class] used for {Model::Children.has_many_relationships}
+      def has_many_relationships_module
+        Import
       end
 
       # Safe to override. Method applied to each cell by default

--- a/lib/csv_row_model/model.rb
+++ b/lib/csv_row_model/model.rb
@@ -1,3 +1,4 @@
+require 'csv_row_model/model/deep_class_var'
 require 'csv_row_model/model/columns'
 require 'csv_row_model/model/children'
 
@@ -10,8 +11,8 @@ module CsvRowModel
       include ActiveModel::Validations
       include Validators::ValidateAttributes
 
+      include DeepClassVar
       include Columns
-
       include Children
 
       # @return [Model] return the parent, if this instance is a child
@@ -39,43 +40,6 @@ module CsvRowModel
     # @return [Boolean] returns true, if the entire csv file should stop reading
     def abort?
       false
-    end
-
-    class_methods do
-
-      protected
-
-      # Returns a memoized variable on the class that included `included_module`
-      #
-      # @param variable_name [Symbol] name of the variable name memoized
-      # @param default_value [Symbol] default value of the memoized variable
-      # @param included_module [Module] module to search for
-      # @return [Object] returns the value of the instance variable of the class that included `included_module`
-      def memoized_class_included_var(variable_name, default_value, included_module)
-        class_included = class_included(included_module)
-        if self == class_included
-          #
-          # equal to: @variable_name ||= default_value
-          #
-          variable_name = "@#{variable_name}"
-          instance_variable_get(variable_name) || instance_variable_set(variable_name, default_value)
-        else
-          class_included.public_send(variable_name)
-        end
-      end
-
-      # Returns the class that included `included_module`, so class variables can be stored there without inheritance prpblems
-      #
-      # @param included_module [Module] module to search for
-      # @return [Class] the class that included `included_module`
-      def class_included(included_module)
-        @class_included ||= {}
-        @class_included[included_module] ||= begin
-          inherited_ancestors = ancestors[0..(ancestors.index(included_module) - 1)]
-          index = inherited_ancestors.rindex {|inherited_ancestor| inherited_ancestor.class == Class }
-          inherited_ancestors[index]
-        end
-      end
     end
   end
 end

--- a/lib/csv_row_model/model/children.rb
+++ b/lib/csv_row_model/model/children.rb
@@ -33,16 +33,25 @@ module CsvRowModel
       end
 
       class_methods do
+        # @return [Hash] map of `relation_name => CsvRowModel::Import or CsvRowModel::Export class`
+        def has_many_relationships
+          deep_class_var :@_has_many_relationships, {}, :merge, has_many_relationships_module
+        end
+
         protected
+        def _has_many_relationships
+          @_has_many_relationships ||= {}
+        end
+
         # Defines a relationship between a row model (only one relation per model for now).
         #
         # @param [Symbol] relation_name the name of the relation
         # @param [CsvRowModel::Import] row_model_class class of the relation
         def has_many(relation_name, row_model_class)
-          raise "for now, CsvRowModel's has_many may only be called once" if has_many_relationships.keys.present?
+          raise "for now, CsvRowModel's has_many may only be called once" if _has_many_relationships.keys.present?
 
           relation_name = relation_name.to_sym
-          has_many_relationships.merge!(relation_name => row_model_class)
+          _has_many_relationships.merge!(relation_name => row_model_class)
 
           define_method(relation_name) do
             #

--- a/lib/csv_row_model/model/columns.rb
+++ b/lib/csv_row_model/model/columns.rb
@@ -17,15 +17,19 @@ module CsvRowModel
       class_methods do
         # @return [Array] column names for the row model
         def column_names
-          memoized_class_included_var :column_names, [], Model
+          deep_class_var :@_column_names, [], :+, Model
         end
 
         protected
+        def _column_names
+          @_column_names ||= []
+        end
+
         # Adds column to the row model
         #
         # @param [Symbol] column_name name of column to add
         def column(column_name)
-          column_names << column_name
+          _column_names << column_name
         end
       end
     end

--- a/lib/csv_row_model/model/deep_class_var.rb
+++ b/lib/csv_row_model/model/deep_class_var.rb
@@ -1,0 +1,28 @@
+module CsvRowModel
+  module Model
+    module DeepClassVar
+      extend ActiveSupport::Concern
+
+      class_methods do
+        protected
+
+        # @param variable_name [Symbol] class variable name (recommend :@_variable_name)
+        # @param default_value [Object] default value of the class variable
+        # @param merge_method [Symbol] method to merge values of the class variable
+        # @param included_module [Module] module to search for
+        # @return [Object] a class variable merged across ancestors until included_module
+        def deep_class_var(variable_name, default_value, merge_method, included_module)
+          value = default_value
+
+          inherited_ancestors = ancestors[0..(ancestors.index(included_module) - 1)]
+          inherited_ancestors.each do |ancestor|
+            ancestor_value = ancestor.instance_variable_get(variable_name)
+            value = ancestor_value.public_send(merge_method, value) if ancestor_value.present?
+          end
+
+          value
+        end
+      end
+    end
+  end
+end

--- a/spec/csv_row_model/model/deep_class_var_spec.rb
+++ b/spec/csv_row_model/model/deep_class_var_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+class Grandparent; end
+module Child; end
+class Parent < Grandparent
+  include Child
+  include CsvRowModel::Model::DeepClassVar
+end
+class ClassWithFamily < Parent; end
+
+describe CsvRowModel::Model::DeepClassVar do
+  describe "class" do
+    describe "::deep_class_var" do
+      let(:variable_name) { :@deep_class_var }
+
+      before do
+        [Grandparent, Parent, Child, ClassWithFamily].each do |klass|
+          klass.instance_variable_set(variable_name, [klass.to_s])
+        end
+      end
+
+      subject { ClassWithFamily.send(:deep_class_var, variable_name, [], :+, Child) }
+
+      it "returns a class variable merged across ancestors until included_module" do
+        expect(subject).to eql %w[Parent ClassWithFamily]
+      end
+    end
+  end
+end

--- a/spec/csv_row_model/model_spec.rb
+++ b/spec/csv_row_model/model_spec.rb
@@ -23,35 +23,4 @@ describe CsvRowModel::Model do
       it "never aborts" do expect(subject).to eql false end
     end
   end
-
-  describe "class" do
-    let(:class_with_family) do
-      class Grandparent; end
-      class Parent < Grandparent; end
-      module Child; end
-      class ClassWithFamily < Parent
-        include Child
-        include CsvRowModel::Model
-      end
-    end
-
-    describe "::memoized_class_included_var" do
-      let(:var_name) { :memoized_var }
-      let(:at_var_name) { "@#{var_name}" }
-      subject { -> { class_with_family.send(:memoized_class_included_var, var_name, Random.rand, CsvRowModel::Model) } }
-
-      it "memoizes the default value" do
-        expect(class_with_family.instance_variable_get(at_var_name)).to eql nil
-        expect(subject.call).to eql subject.call
-        expect(class_with_family.instance_variable_get(at_var_name)).to eql subject.call
-      end
-    end
-
-    describe "::class_included" do
-      subject { class_with_family.send(:class_included, CsvRowModel::Model) }
-      it "gets the class that included CsvRowModel::Model" do
-        expect(subject).to eql class_with_family
-      end
-    end
-  end
 end


### PR DESCRIPTION
fixes subclassing on calling `column` or `has_many`.

this makes the class variable setting implementation move across ancestors... i.e.:

``` ruby
class BasicModel1
  include CsvRowModel::Model
  column :string1
end
class BasicModel2 < BasicModel1
  include CsvRowModel::Model
  column :string2
end
class BasicModel3 < BasicModel2
  include CsvRowModel::Model
  column :string3
end

# the fix
BasicModel1.columns #=> [:string1]
BasicModel2.columns #=> [:string1, :string2]
BasicModel3.columns #=> [:string1, :string2, :string3]

# previous was:
BasicModel1.columns == BasicModel2.columns == BasicModel3.columns  #=> [:string1, :string2, :string3]
```
