### PR TITLE
handle validations with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ import_mapper.project.name # => "SOME PROJECT NAME"
 ### Default Attributes
 For `Import`, `default_attributes` are calculated as thus:
 - `format_cell`
-- if `value_from_format_cell.blank? || csv_string_model.errors[column_name].blank?`, `default_lambda.call` or nil
+- if `value_from_format_cell.blank?`, `default_lambda.call` or nil
 - otherwise, `parse_lambda.call`
 
 #### Format Cell
@@ -163,7 +163,7 @@ end
 ```
 
 #### Default
-Called when `format_cell` is `value_from_format_cell.blank? || csv_string_model.errors[column_name].blank?`, it sets the default value of the cell:
+Called when `format_cell` is `value_from_format_cell.blank?`, it sets the default value of the cell:
 ```ruby
 class ProjectImportRowModel < ProjectRowModel
   include CsvRowModel::Import

--- a/lib/csv_row_model/import.rb
+++ b/lib/csv_row_model/import.rb
@@ -58,7 +58,7 @@ module CsvRowModel
 
       proc = -> do
         csv_string_model.valid?(*args)
-        errors.messages.merge!(csv_string_model.errors.messages)
+        errors.messages.merge!(csv_string_model.errors.messages.reject {|k, v| v.empty? })
         errors.empty?
       end
 

--- a/lib/csv_row_model/import/attributes.rb
+++ b/lib/csv_row_model/import/attributes.rb
@@ -29,10 +29,12 @@ module CsvRowModel
       # @return [Object] the column's attribute before override
       def original_attribute(column_name)
         @default_changes ||= {}
-        value = self.class.format_cell(mapped_row[column_name], column_name, self.class.index(column_name))
 
         csv_string_model.valid?
-        if value.present? && csv_string_model.errors[column_name].blank?
+        return nil unless csv_string_model.errors[column_name].blank?
+
+        value = self.class.format_cell(mapped_row[column_name], column_name, self.class.index(column_name))
+        if value.present?
           instance_exec(value, &self.class.parse_lambda(column_name))
         elsif self.class.options(column_name)[:default]
           original_value = value

--- a/spec/csv_row_model/import/attributes_spec.rb
+++ b/spec/csv_row_model/import/attributes_spec.rb
@@ -80,8 +80,8 @@ describe CsvRowModel::Import::Attributes do
             end
           end
 
-          it "returns the default" do
-            expect(subject).to eql(123)
+          it "returns nil" do
+            expect(subject).to eql(nil)
           end
         end
       end
@@ -148,9 +148,11 @@ describe CsvRowModel::Import::Attributes do
     end
 
     describe "::default_lambda" do
-      let(:source_row) { ['a', nil] }
+      let(:instance) { import_model_klass.new(source_row) }
 
-      context "try to looking for in another field" do
+      context "when looking for in another field for default" do
+        let(:source_row) { ['a', nil] }
+
         before do
           import_model_klass.instance_eval do
             column :string1
@@ -158,13 +160,10 @@ describe CsvRowModel::Import::Attributes do
           end
         end
 
+
         it "returns the default" do
-          expect(
-            import_model_klass.new(source_row).original_attributes[:string1]
-          ).to eql('a')
-          expect(
-            import_model_klass.new(source_row).original_attributes[:string2]
-          ).to eql('a')
+          expect(instance.original_attributes[:string1]).to eql('a')
+          expect(import_model_klass.new(source_row).original_attributes[:string2]).to eql('a')
         end
       end
     end

--- a/spec/csv_row_model/import_spec.rb
+++ b/spec/csv_row_model/import_spec.rb
@@ -74,6 +74,25 @@ describe CsvRowModel::Import do
           end
         end
 
+        context "when setting default, but invalid csv_string_model validation" do
+          let(:source_row) { ["1", ""]}
+
+          before do
+            import_model_klass.instance_eval do
+              column :name, default: "the default!"
+
+              csv_string_model do
+                validates :name, presence: true
+              end
+            end
+          end
+
+          it "returns just invalid" do
+            expect(subject).to eql false
+            expect(instance.errors.full_messages).to eql ["Name can't be blank"]
+          end
+        end
+
         context "overriding validations" do
           before do
             import_model_klass.instance_eval do
@@ -95,6 +114,19 @@ describe CsvRowModel::Import do
             it "just shows the csv_string_model_class validation" do
               expect(subject).to eql false
               expect(instance.errors.full_messages).to eql ["Id can't be blank"]
+            end
+          end
+
+          context "with errors has a key with empty value" do
+            before do
+              instance.csv_string_model.valid?
+            end
+
+            it "still shows the non-string validation" do
+              expect(subject).to eql false
+              expect(instance.csv_string_model.errors[:id]).to eql([])
+              expect(instance.csv_string_model.errors.messages).to eql(id: [])
+              expect(instance.errors.full_messages).to eql ["Id is too short (minimum is 5 characters)"]
             end
           end
         end


### PR DESCRIPTION
found a bug.

realized it was a bad idea to set default if `csv_string_model` is invalid. 

so if: `csv_string_model.invalid?` and a default is set, the model is invalid and it skips.

it was a bad idea in general.
