### PR TITLE
removing check dependencies using #valid? on calling presenter attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,10 +328,10 @@ Also, the `attribute` defines a dynamic `#project` method that:
 
 1. Memoizes by default, turn off with `memoize: false` option
 2. All errors of `row_model` are propagated to the presenter when calling `presenter.valid?`
-3. When any of the dependencies are `invalid?`, `presenter.errors` for dependencies are cleaned. For the example above, if `row_model.id/name` are `invalid?`, then
+3. Handles dependencies:
+  - When any of the dependencies are `blank?`, the attribute block is not called and the attribute returns `nil`.
+  - When any of the dependencies are `invalid?`, `presenter.errors` for dependencies are cleaned. For the example above, if `row_model.id/name` are `invalid?`, then
 the `:project` key is removed from the errors, so: `presenter.errors.keys # => [:id, :name]`
-
-What happens to errors also happens to [`ActiveWarnings`](https://github.com/s12chung/active_warnings).
 
 ## Import Validations
 

--- a/README.md
+++ b/README.md
@@ -328,10 +328,10 @@ Also, the `attribute` defines a dynamic `#project` method that:
 
 1. Memoizes by default, turn off with `memoize: false` option
 2. All errors of `row_model` are propagated to the presenter when calling `presenter.valid?`
-3. Handles dependencies:
-  - When any of the dependencies are `blank?`, the attribute block is not called and the attribute returns `nil`.
-  - When any of the dependencies are `invalid?`, `presenter.errors` for dependencies are cleaned. For the example above, if `row_model.id/name` are `invalid?`, then
+3. When any of the dependencies are `invalid?`, `presenter.errors` for dependencies are cleaned. For the example above, if `row_model.id/name` are `invalid?`, then
 the `:project` key is removed from the errors, so: `presenter.errors.keys # => [:id, :name]`
+
+What happens to errors also happens to [`ActiveWarnings`](https://github.com/s12chung/active_warnings).
 
 ## Import Validations
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ class ProjectImportRowModel < ProjectRowModel
 
     # this is shorthand for the psuedo_code:
     # def project
-    #  return if row_model.id.invalid? || row_model.name.invalid?
+    #  return if row_model.id.blank? || row_model.name.blank?
     #
     #  # turn off memoziation with `memoize: false` option
     #  @project ||= __the_code_inside_the_block__
@@ -328,9 +328,9 @@ Also, the `attribute` defines a dynamic `#project` method that:
 
 1. Memoizes by default, turn off with `memoize: false` option
 2. All errors of `row_model` are propagated to the presenter when calling `presenter.valid?`
-3. Handles dependencies. When any of the dependencies are `invalid?`:
-  - The attribute block is not called and the attribute returns `nil`.
-  - `presenter.errors` for dependencies are cleaned. For the example above, if `row_model.id/name` are `invalid?`, then
+3. Handles dependencies:
+  - When any of the dependencies are `blank?`, the attribute block is not called and the attribute returns `nil`.
+  - When any of the dependencies are `invalid?`, `presenter.errors` for dependencies are cleaned. For the example above, if `row_model.id/name` are `invalid?`, then
 the `:project` key is removed from the errors, so: `presenter.errors.keys # => [:id, :name]`
 
 ## Import Validations

--- a/lib/csv_row_model/import/presenter.rb
+++ b/lib/csv_row_model/import/presenter.rb
@@ -72,12 +72,6 @@ module CsvRowModel
         true
       end
 
-      # @param [Symbol] attribute_name the attribute to check
-      # @return [Boolean] if the dependencies are valid
-      def valid_dependencies?(attribute_name)
-        row_model_present?(*self.class.options(attribute_name)[:dependencies])
-      end
-
       # equal to: @method_name ||= yield
       # @param [Symbol] method_name method_name in description
       # @return [Object] the memoized result
@@ -141,7 +135,6 @@ module CsvRowModel
           define_method("__#{attribute_name}", &block(attribute_name))
 
           define_method(attribute_name) do
-            return unless valid_dependencies?(attribute_name)
             self.class.options(attribute_name)[:memoize] ?
               memoize(attribute_name) { public_send("__#{attribute_name}") } :
               public_send("__#{attribute_name}")

--- a/lib/csv_row_model/import/presenter.rb
+++ b/lib/csv_row_model/import/presenter.rb
@@ -72,6 +72,12 @@ module CsvRowModel
         true
       end
 
+      # @param [Symbol] attribute_name the attribute to check
+      # @return [Boolean] if the dependencies are valid
+      def valid_dependencies?(attribute_name)
+        row_model_present?(*self.class.options(attribute_name)[:dependencies])
+      end
+
       # equal to: @method_name ||= yield
       # @param [Symbol] method_name method_name in description
       # @return [Object] the memoized result
@@ -135,6 +141,7 @@ module CsvRowModel
           define_method("__#{attribute_name}", &block(attribute_name))
 
           define_method(attribute_name) do
+            return unless valid_dependencies?(attribute_name)
             self.class.options(attribute_name)[:memoize] ?
               memoize(attribute_name) { public_send("__#{attribute_name}") } :
               public_send("__#{attribute_name}")

--- a/lib/csv_row_model/import/presenter.rb
+++ b/lib/csv_row_model/import/presenter.rb
@@ -66,15 +66,16 @@ module CsvRowModel
       end
 
       # @param [Array] Array of column_names to check
-      # @return [Boolean] if column_names are valid
-      def row_model_valid?(*column_names)
-        row_model.valid? || (row_model.errors.keys & column_names).empty?
+      # @return [Boolean] if column_names are present
+      def row_model_present?(*column_names)
+        column_names.each { |column_name| return false if row_model.public_send(column_name).blank? }
+        true
       end
 
       # @param [Symbol] attribute_name the attribute to check
       # @return [Boolean] if the dependencies are valid
       def valid_dependencies?(attribute_name)
-        row_model_valid?(*self.class.options(attribute_name)[:dependencies])
+        row_model_present?(*self.class.options(attribute_name)[:dependencies])
       end
 
       # equal to: @method_name ||= yield

--- a/spec/csv_row_model/import/presenter_spec.rb
+++ b/spec/csv_row_model/import/presenter_spec.rb
@@ -50,6 +50,15 @@ describe CsvRowModel::Import::Presenter do
           expect(instance.attribute2).to eql nil
         end
       end
+
+      context "with row_model errors" do
+        let(:source_row) {["", ""] }
+
+        it "should just return nil" do
+          expect(Random).to_not receive(:rand)
+          expect(subject).to eql nil
+        end
+      end
     end
 
     describe "#valid?" do
@@ -88,17 +97,18 @@ describe CsvRowModel::Import::Presenter do
       end
     end
 
-    describe "#row_model_present?" do
-      subject { instance.send :row_model_present?, :string1, :string2 }
+    describe "#valid_dependencies?" do
+      subject { instance.send :valid_dependencies?, :attribute1 }
+      before { instance.errors.add(:attribute1) }
 
       it "returns true" do
         expect(subject).to eql true
       end
 
-      context "with blank attributes" do
-        let(:source_row) { ["", ""] }
+      context "returns false" do
+        let(:source_row) {["", ""] }
 
-        it "returns false" do
+        it "only has row_model errors" do
           expect(subject).to eql false
         end
       end

--- a/spec/csv_row_model/import/presenter_spec.rb
+++ b/spec/csv_row_model/import/presenter_spec.rb
@@ -50,15 +50,6 @@ describe CsvRowModel::Import::Presenter do
           expect(instance.attribute2).to eql nil
         end
       end
-
-      context "with row_model errors" do
-        let(:source_row) {["", ""] }
-
-        it "should just return nil" do
-          expect(Random).to_not receive(:rand)
-          expect(subject).to eql nil
-        end
-      end
     end
 
     describe "#valid?" do
@@ -97,18 +88,17 @@ describe CsvRowModel::Import::Presenter do
       end
     end
 
-    describe "#valid_dependencies?" do
-      subject { instance.send :valid_dependencies?, :attribute1 }
-      before { instance.errors.add(:attribute1) }
+    describe "#row_model_present?" do
+      subject { instance.send :row_model_present?, :string1, :string2 }
 
       it "returns true" do
         expect(subject).to eql true
       end
 
-      context "returns false" do
-        let(:source_row) {["", ""] }
+      context "with blank attributes" do
+        let(:source_row) { ["", ""] }
 
-        it "only has row_model errors" do
+        it "returns false" do
           expect(subject).to eql false
         end
       end


### PR DESCRIPTION
checking dependencies based on `#valid?` is silly because there are skipping.

so using `#blank?` instead.
