### PR TITLE
proxy for Export::File

### DIFF
--- a/lib/csv_row_model/export/file.rb
+++ b/lib/csv_row_model/export/file.rb
@@ -38,7 +38,7 @@ module CsvRowModel
         CSV.open(file.path, "wb") do |csv|
           @csv = csv
           export_model_class.setup(csv, context, with_headers: with_headers)
-          yield self
+          yield Proxy.new(self)
         end
       ensure
         @csv = nil
@@ -46,6 +46,17 @@ module CsvRowModel
 
       def to_s
         file.read
+      end
+
+      class Proxy
+        def initialize(file)
+          @file = file
+        end
+
+        def append_model(*args)
+          @file.append_model(*args)
+        end
+        alias_method :<<, :append_model
       end
     end
   end

--- a/spec/csv_row_model/export/file_spec.rb
+++ b/spec/csv_row_model/export/file_spec.rb
@@ -24,6 +24,7 @@ describe CsvRowModel::Export::File do
         expect(instance.generated?).to eql false
 
         instance.generate do |csv|
+          expect(csv.class).to_not eql described_class
           csv.append_model(model, another_context: true)
         end
         expect(instance.generated?).to eql true


### PR DESCRIPTION
use proxy to shield calling wierd methods on Export::File when passing it in block

closes #42
