### PR TITLE
hidden_module

### DIFF
--- a/lib/csv_row_model.rb
+++ b/lib/csv_row_model.rb
@@ -16,6 +16,7 @@ if autoload && defined?(Rails)
   require 'csv_row_model/engine'
 else
   require 'csv_row_model/concerns/inspect'
+  require 'csv_row_model/concerns/hidden_module'
   require 'csv_row_model/concerns/check_options'
 
   require 'csv_row_model/validators/validate_attributes'

--- a/lib/csv_row_model/concerns/hidden_module.rb
+++ b/lib/csv_row_model/concerns/hidden_module.rb
@@ -1,0 +1,17 @@
+module CsvRowModel
+  module Concerns
+    module HiddenModule
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def hidden_module
+          @hidden_module ||= Module.new.tap { |mod| include mod }
+        end
+
+        def define_proxy_method(*args, &block)
+          hidden_module.send(:define_method, *args, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/csv_row_model/export/attributes.rb
+++ b/lib/csv_row_model/export/attributes.rb
@@ -38,7 +38,7 @@ module CsvRowModel
         # @param column_name [Symbol] the cell's column_name
         def define_attribute_method(column_name)
           return if method_defined? column_name
-          define_method(column_name) { source_model.public_send(column_name) }
+          define_proxy_method(column_name) { source_model.public_send(column_name) }
         end
       end
     end

--- a/lib/csv_row_model/export/dynamic_columns.rb
+++ b/lib/csv_row_model/export/dynamic_columns.rb
@@ -37,7 +37,7 @@ module CsvRowModel
         # Define default attribute method for a dynamic_column
         # @param column_name [Symbol] the cell's column_name
         def define_dynamic_attribute_method(column_name)
-          define_method(column_name) { formatted_attribute(column_name) }
+          define_proxy_method(column_name) { formatted_attribute(column_name) }
           DynamicColumnCell.define_process_cell(self, column_name)
         end
       end

--- a/lib/csv_row_model/import/attributes.rb
+++ b/lib/csv_row_model/import/attributes.rb
@@ -58,7 +58,7 @@ module CsvRowModel
         def define_attribute_method(column_name)
           return if method_defined? column_name
           csv_string_model_class.add_type_validation(column_name, columns[column_name])
-          define_method(column_name) { original_attribute(column_name) }
+          define_proxy_method(column_name) { original_attribute(column_name) }
         end
       end
     end

--- a/lib/csv_row_model/import/dynamic_columns.rb
+++ b/lib/csv_row_model/import/dynamic_columns.rb
@@ -50,7 +50,7 @@ module CsvRowModel
         # Define default attribute method for a column
         # @param column_name [Symbol] the cell's column_name
         def define_dynamic_attribute_method(column_name)
-          define_method(column_name) { original_attribute(column_name) }
+          define_proxy_method(column_name) { original_attribute(column_name) }
           DynamicColumnCell.define_process_cell(self, column_name)
         end
       end

--- a/lib/csv_row_model/import/representation.rb
+++ b/lib/csv_row_model/import/representation.rb
@@ -52,7 +52,7 @@ module CsvRowModel
         end
 
         def define_lambda_method(row_model_class, representation_name, &block)
-          row_model_class.send(:define_method, lambda_name(representation_name), &block)
+          row_model_class.define_proxy_method(lambda_name(representation_name), &block)
         end
       end
     end

--- a/lib/csv_row_model/import/represents.rb
+++ b/lib/csv_row_model/import/represents.rb
@@ -76,7 +76,7 @@ module CsvRowModel
         def define_representation_method(representation_name, options={}, &block)
           Representation.check_options(options)
           merge_representations(representation_name.to_sym => options)
-          define_method(representation_name) { representation_value(representation_name) }
+          define_proxy_method(representation_name) { representation_value(representation_name) }
           Representation.define_lambda_method(self, representation_name, &block)
         end
       end

--- a/lib/csv_row_model/model.rb
+++ b/lib/csv_row_model/model.rb
@@ -9,6 +9,8 @@ module CsvRowModel
   module Model
     extend ActiveSupport::Concern
 
+    include Concerns::HiddenModule
+
     include InheritedClassVar
 
     include ActiveWarnings

--- a/lib/csv_row_model/model/children.rb
+++ b/lib/csv_row_model/model/children.rb
@@ -55,7 +55,7 @@ module CsvRowModel
 
           merge_has_many_relationships(relation_name => row_model_class)
 
-          define_method(relation_name) do
+          define_proxy_method(relation_name) do
             #
             # equal to: @relation_name ||= []
             #

--- a/lib/csv_row_model/model/dynamic_column_cell.rb
+++ b/lib/csv_row_model/model/dynamic_column_cell.rb
@@ -36,7 +36,7 @@ module CsvRowModel
         # process_cell = one cell
         # attribute_method = many cells = [process_cell(), process_cell()...]
         def define_process_cell(row_model_class, column_name, &block)
-          row_model_class.send(:define_method, process_cell_method_name(column_name), &block)
+          row_model_class.define_proxy_method(process_cell_method_name(column_name), &block)
         end
       end
     end

--- a/spec/csv_row_model/concerns/hidden_module_spec.rb
+++ b/spec/csv_row_model/concerns/hidden_module_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe CsvRowModel::Concerns::HiddenModule do
+  let(:klass1) { Class.new { include CsvRowModel::Concerns::HiddenModule } }
+  let(:klass2) { Class.new { include CsvRowModel::Concerns::HiddenModule } }
+  let(:subclass1) { Class.new(klass1) }
+
+  describe "class" do
+    before { klass1.hidden_module }
+
+    describe "included" do
+      it "includes the hidden module in the class" do
+        expect(klass1.included_modules.index(klass1.hidden_module)).to eql 0
+      end
+    end
+
+    describe "defining method" do
+      subject { klass1.new.waka }
+
+      before { klass1.define_proxy_method(:waka) { "in module" } }
+
+      it "works" do
+        expect(subject).to eql "in module"
+      end
+
+      context "with super method defined" do
+        let(:klass1) do
+          Class.new do
+            include CsvRowModel::Concerns::HiddenModule
+            def waka; super end
+          end
+        end
+
+        it "can call super" do
+          expect(subject).to eql "in module"
+        end
+      end
+    end
+
+    describe "::hidden_module" do
+      subject { klass1.hidden_module }
+
+      it "returns the module memoized" do
+        expect(subject.class).to eql Module
+        expect(subject.object_id).to eql klass1.hidden_module.object_id
+        expect(subject.object_id).to_not eql klass2.hidden_module.object_id
+      end
+    end
+  end
+end

--- a/spec/csv_row_model/export/dynamic_column_cell_spec.rb
+++ b/spec/csv_row_model/export/dynamic_column_cell_spec.rb
@@ -65,7 +65,7 @@ describe CsvRowModel::Export::DynamicColumnCell do
 
     describe "class" do
       describe "::define_process_cell" do
-        let(:klass) { Class.new }
+        let(:klass) { Class.new { include CsvRowModel::Concerns::HiddenModule } }
         subject { described_class.define_process_cell(klass, :somethings) }
 
         it "adds the process method to the class" do

--- a/spec/csv_row_model/import/attributes_spec.rb
+++ b/spec/csv_row_model/import/attributes_spec.rb
@@ -90,7 +90,7 @@ describe CsvRowModel::Import::Attributes do
       let(:original_options) { {} }
 
       it "adds validations" do
-        expect(row_model_class).to_not receive(:define_method)
+        expect(row_model_class).to_not receive(:define_proxy_method)
         expect(row_model_class.csv_string_model_class).to receive(:add_type_validation).once.and_call_original
         subject
       end
@@ -99,7 +99,7 @@ describe CsvRowModel::Import::Attributes do
         let(:original_options) { { type: Integer, validate_type: true } }
 
         it "doesn't add validations" do
-          expect(row_model_class).to_not receive(:define_method)
+          expect(row_model_class).to_not receive(:define_proxy_method)
           expect(row_model_class.csv_string_model_class).to_not receive(:add_type_validation)
 
           subject

--- a/spec/csv_row_model/import/dynamic_column_cell_spec.rb
+++ b/spec/csv_row_model/import/dynamic_column_cell_spec.rb
@@ -88,7 +88,7 @@ describe CsvRowModel::Import::DynamicColumnCell do
 
   describe "class" do
     describe "::define_process_cell" do
-      let(:klass) { Class.new }
+      let(:klass) { Class.new { include CsvRowModel::Concerns::HiddenModule } }
       subject { described_class.define_process_cell(klass, :somethings) }
 
       it "adds the process method to the class" do

--- a/spec/csv_row_model/import/representation_spec.rb
+++ b/spec/csv_row_model/import/representation_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe CsvRowModel::Import::Representation do
   describe "instance" do
     let(:instance) { described_class.new(:string1, options, row_model) }
-    let(:row_model) { OpenStruct.new }
+    let(:row_model) { BasicImportModel.new }
     let(:options) { {} }
 
     let(:block) { Proc.new { "string1" } }
@@ -96,14 +96,14 @@ describe CsvRowModel::Import::Representation do
       end
 
       context "dependency is provided" do
-        let(:options) { { dependencies: %i[dep1 dep2] } }
+        let(:options) { { dependencies: %i[string1 string1] } }
 
         it "returns false" do
           expect(subject).to eql false
         end
 
         context "when dependency is not blank" do
-          let(:row_model) { OpenStruct.new(dep1: "dep", dep2: "dep") }
+          let(:row_model) { BasicImportModel.new(%w[dep1 dep2]) }
 
           it "returns true" do
             expect(subject).to eql true
@@ -178,7 +178,7 @@ describe CsvRowModel::Import::Representation do
     end
 
     describe "::define_lambda_method" do
-      let(:klass) { Class.new }
+      let(:klass) { Class.new { include CsvRowModel::Concerns::HiddenModule } }
       subject { described_class.define_lambda_method(klass, :some_name) { return "test" } }
 
       it "adds the process method to the class" do

--- a/spec/support/shared_examples/methods/define_attribute_method.rb
+++ b/spec/support/shared_examples/methods/define_attribute_method.rb
@@ -1,7 +1,7 @@
 shared_examples "define_attribute_method" do
   it "does not do anything the second time" do
-    expect(row_model_class).to receive(:define_method).with(:waka).once.and_call_original
-    expect(row_model_class).to receive(:define_method).with(:waka2).once.and_call_original
+    expect(row_model_class).to receive(:define_proxy_method).with(:waka).once.and_call_original
+    expect(row_model_class).to receive(:define_proxy_method).with(:waka2).once.and_call_original
 
     row_model_class.send(:define_attribute_method, :waka)
     row_model_class.send(:define_attribute_method, :waka)


### PR DESCRIPTION
Adds the ability to call `super` on our attributes.

When calling `define_method` on our classes and overriding the method, it's almost the same as:

``` ruby
class RowModel
  define_method(:id) { original_attribute(:id) }
  def id; super.override_id_implementation end
end
```

`super` doesn't work because it's defining the same function on the same class and there is no parent class, so we usually call `original_attribute(:id)` (the original implementation) instead of `super`.

You can't call `define_method` on `csv_row_model` `module`s because it'll change any class that includes the module. So we create a hidden module to define methods, like this:

``` ruby
class RowModel
  mod = Module.new { define_method(:id) { original_attribute(:id) } }
  include mod

  def id; super.override_id_implementation end
end
```

And `super` will work. This is what [`active_record` does internally](https://github.com/rails/rails/blob/52ce6ece8c8f74064bb64e0a0b1ddd83092718e1/activemodel/lib/active_model/attribute_methods.rb#L368-L388).
