### PR TITLE
make check_options refer to the files using the options

### DIFF
--- a/lib/csv_row_model.rb
+++ b/lib/csv_row_model.rb
@@ -6,8 +6,6 @@ require 'csv'
 require 'active_model'
 require 'active_warnings'
 
-require 'csv_row_model/concerns/check_options'
-
 require 'csv_row_model/public/model'
 require 'csv_row_model/public/model/file_model'
 

--- a/lib/csv_row_model/concerns/check_options.rb
+++ b/lib/csv_row_model/concerns/check_options.rb
@@ -3,9 +3,14 @@ module CsvRowModel
     extend ActiveSupport::Concern
 
     class_methods do
-      def check_options(options)
-        invalid_options = options.keys - self::VALID_OPTIONS
+      def check_options(*klasses)
+        options = klasses.extract_options!
+        valid_options = klasses.map {|klass| klass.try(:valid_options) }.compact.flatten
+
+        invalid_options = options.keys - valid_options
         raise ArgumentError.new("Invalid option(s): #{invalid_options}") if invalid_options.present?
+
+        klasses.each { |klass| klass.try(:custom_check_options, options) }
         true
       end
     end

--- a/lib/csv_row_model/concerns/import/csv_string_model.rb
+++ b/lib/csv_row_model/concerns/import/csv_string_model.rb
@@ -48,13 +48,20 @@ module CsvRowModel
         PARSE_VALIDATION_CLASSES = [Boolean, Integer, Float, Date, DateTime].freeze
 
         class << self
+          def valid_options
+            %i[type validate_type]
+          end
+
+          def custom_check_options(options)
+            return unless options[:validate_type] && !PARSE_VALIDATION_CLASSES.include?(options[:type])
+            raise ArgumentError.new("with :validate_type, :type must be #{PARSE_VALIDATION_CLASSES.join(", ")}")
+          end
+
           # Adds the type validation based on :validate_type option
           def add_type_validation(column_name, options)
             return unless options[:validate_type]
 
             type = options[:type]
-            raise ArgumentError.new("invalid :type given for :validate_type for: #{column_name}") unless PARSE_VALIDATION_CLASSES.include? type
-
             class_eval { validates column_name, :"#{type.name.underscore}_format" => true, allow_blank: true }
           end
         end

--- a/lib/csv_row_model/concerns/import/represents.rb
+++ b/lib/csv_row_model/concerns/import/represents.rb
@@ -1,9 +1,11 @@
+require 'csv_row_model/concerns/check_options'
 require 'csv_row_model/internal/import/representation'
 
 module CsvRowModel
   module Import
     module Represents
       extend ActiveSupport::Concern
+      include CheckOptions
 
       included do
         inherited_class_hash :representations
@@ -74,7 +76,7 @@ module CsvRowModel
         end
 
         def define_representation_method(representation_name, options={}, &block)
-          Representation.check_options(options)
+          check_options Representation, options
           representations_object.merge(representation_name.to_sym => options)
           define_proxy_method(representation_name) { representation_value(representation_name) }
           Representation.define_lambda_method(self, representation_name, &block)

--- a/lib/csv_row_model/concerns/model/attributes.rb
+++ b/lib/csv_row_model/concerns/model/attributes.rb
@@ -1,4 +1,5 @@
 require 'inherited_class_var'
+require 'csv_row_model/concerns/check_options'
 require 'csv_row_model/internal/model/header'
 
 module CsvRowModel
@@ -6,6 +7,7 @@ module CsvRowModel
     module Attributes
       extend ActiveSupport::Concern
       include InheritedClassVar
+      include CheckOptions
 
       included do
         inherited_class_hash :columns
@@ -51,8 +53,6 @@ module CsvRowModel
 
         protected
 
-        VALID_OPTIONS_KEYS = %i[type parse validate_type default header].freeze
-
         # Adds column to the row model
         #
         # @param [Symbol] column_name name of column to add
@@ -67,12 +67,12 @@ module CsvRowModel
         # @option options [String] :header human friendly string of the column name, by default format_header(column_name)
         # @option options [Hash] :header_matchs array with string to match cell to find in the row, by default column name
         def column(column_name, options={})
-          column_name = column_name.to_sym
+          check_options Model::Header,
+                        Import::CsvStringModel::Model,
+                        Import::Attribute,
+                        options
 
-          extra_keys = options.keys - VALID_OPTIONS_KEYS
-          raise ArgumentError.new("invalid options #{extra_keys}") unless extra_keys.empty?
-
-          columns_object.merge(column_name => options)
+          columns_object.merge(column_name.to_sym => options)
         end
 
         def merge_options(column_name, options={})

--- a/lib/csv_row_model/concerns/model/dynamic_columns.rb
+++ b/lib/csv_row_model/concerns/model/dynamic_columns.rb
@@ -1,10 +1,12 @@
 require 'csv_row_model/internal/model/dynamic_column_header'
+require 'csv_row_model/concerns/check_options'
 
 module CsvRowModel
   module Model
     module DynamicColumns
       extend ActiveSupport::Concern
       include InheritedClassVar
+      include CheckOptions
 
       included do
         inherited_class_hash :dynamic_columns
@@ -52,16 +54,12 @@ module CsvRowModel
 
         protected
 
-        VALID_OPTIONS_KEYS = %i[header header_models_context_key].freeze
-
         # define a dynamic_column, must be after all normal columns
         #
         # @param column_name [Symbol] column_name
         # @option options [String] :header human friendly string of the column name, by default format_header(column_name)
         def dynamic_column(column_name, options={})
-          extra_keys = options.keys - VALID_OPTIONS_KEYS
-          raise ArgumentError.new("invalid options #{extra_keys}") unless extra_keys.empty?
-
+          check_options DynamicColumnHeader, options
           dynamic_columns_object.merge(column_name.to_sym => options)
         end
       end

--- a/lib/csv_row_model/internal/concerns/dynamic_column_shared.rb
+++ b/lib/csv_row_model/internal/concerns/dynamic_column_shared.rb
@@ -3,6 +3,8 @@ require 'csv_row_model/internal/concerns/column_shared'
 module CsvRowModel
   module DynamicColumnShared
     include ColumnShared
+    extend ActiveSupport::Concern
+
     #
     # row_model_class
     #
@@ -23,6 +25,12 @@ module CsvRowModel
 
     def header_models_context_key
       options[:header_models_context_key] || column_name
+    end
+
+    class_methods do
+      def valid_options
+        super + %i[header_models_context_key]
+      end
     end
   end
 end

--- a/lib/csv_row_model/internal/import/attribute.rb
+++ b/lib/csv_row_model/internal/import/attribute.rb
@@ -57,11 +57,20 @@ module CsvRowModel
       # @return [Lambda, Proc] returns the Lambda/Proc given in the parse option or:
       # ->(source_value) { parse_proc_exists? ? parsed_value : source_value  }
       def parse_lambda
-        raise ArgumentError.new("Use :parse OR :type option, but not both for: #{column_name}") if options[:parse] && options[:type]
-
         parse_lambda = options[:parse] || CLASS_TO_PARSE_LAMBDA[options[:type]]
         return parse_lambda if parse_lambda
-        raise ArgumentError.new("type must be #{CLASS_TO_PARSE_LAMBDA.keys.reject(:nil?).join(", ")} for: #{column_name}")
+      end
+
+      class << self
+        def custom_check_options(options)
+          raise ArgumentError.new("Use :parse OR :type option, but not both") if options[:parse] && options[:type]
+          return if options[:parse] || CLASS_TO_PARSE_LAMBDA[options[:type]]
+          raise ArgumentError.new(":type must be #{CLASS_TO_PARSE_LAMBDA.keys.reject(&:nil?).join(", ")}")
+        end
+
+        def valid_options
+          %i[type parse default]
+        end
       end
     end
   end

--- a/lib/csv_row_model/internal/import/representation.rb
+++ b/lib/csv_row_model/internal/import/representation.rb
@@ -1,9 +1,6 @@
 module CsvRowModel
   module Import
     class Representation
-      include CheckOptions
-      VALID_OPTIONS = %i[memoize empty_value dependencies].freeze
-
       attr_reader :name, :options, :row_model
 
       def initialize(name, options, row_model)
@@ -53,6 +50,10 @@ module CsvRowModel
 
         def define_lambda_method(row_model_class, representation_name, &block)
           row_model_class.define_proxy_method(lambda_name(representation_name), &block)
+        end
+
+        def valid_options
+          %i[memoize empty_value dependencies]
         end
       end
     end

--- a/lib/csv_row_model/internal/model/header.rb
+++ b/lib/csv_row_model/internal/model/header.rb
@@ -20,6 +20,12 @@ module CsvRowModel
       def formatted_header
         row_model_class.format_header(column_name, column_index, context)
       end
+
+      class << self
+        def valid_options
+          %i[header]
+        end
+      end
     end
   end
 end

--- a/spec/csv_row_model/concerns/check_options_spec.rb
+++ b/spec/csv_row_model/concerns/check_options_spec.rb
@@ -1,25 +1,72 @@
 require 'spec_helper'
 
-class CheckOptions
+class UsesOptions
+  class << self
+    def valid_options; %i[option1] end
+  end
+end
+
+class UsesMoreOptions
+  class << self
+    def valid_options; %i[option1 option2] end
+
+    def custom_check_options(options) raise ArgumentError.new("UsesMoreOptions raise_error! test") if options[:option1] == "raise_error!" end
+  end
+end
+
+class DoesNothing; end
+
+class ChecksOptions
   include CsvRowModel::CheckOptions
-  VALID_OPTIONS = %i[option1 option2]
 end
 
 describe CsvRowModel::CheckOptions do
   describe "class" do
     describe "::check_options" do
-      let(:klass) { CheckOptions }
+      let(:klass) { ChecksOptions }
 
-      subject { klass.check_options(option1: nil, option2: nil) }
+      subject { klass.check_options(UsesOptions, UsesMoreOptions, option1: nil, option2: nil) }
       it "returns true" do
         expect(subject).to eql true
       end
 
       context "with invalid option" do
-        subject { klass.check_options(option1: nil, invalid_option: nil) }
+        subject { klass.check_options(UsesOptions, UsesMoreOptions, option1: nil, invalid_option: nil) }
 
         it "raises error" do
           expect { subject }.to raise_error(ArgumentError, "Invalid option(s): [:invalid_option]")
+        end
+      end
+
+      context "with extra option not used" do
+        subject { klass.check_options(UsesOptions, option1: nil, option2: nil) }
+
+        it "raises error" do
+          expect { subject }.to raise_error(ArgumentError, "Invalid option(s): [:option2]")
+        end
+      end
+
+      context "with no valid options set on a class" do
+        subject { klass.check_options(UsesOptions, DoesNothing, option1: nil) }
+
+        it "does nothing" do
+          subject
+        end
+
+        context "with nil key" do
+          subject { klass.check_options(UsesOptions, DoesNothing, option1: nil, nil => "blah") }
+
+          it "raises error" do
+            expect { subject }.to raise_error(ArgumentError, "Invalid option(s): [nil]")
+          end
+        end
+      end
+
+      context "with custom_check_options Error" do
+        subject { klass.check_options(UsesOptions, UsesMoreOptions, option1: "raise_error!", option2: nil) }
+
+        it "raises error" do
+          expect { subject }.to raise_error(ArgumentError, "UsesMoreOptions raise_error! test")
         end
       end
     end

--- a/spec/csv_row_model/concerns/import/csv_string_model_spec.rb
+++ b/spec/csv_row_model/concerns/import/csv_string_model_spec.rb
@@ -147,10 +147,29 @@ describe CsvRowModel::Import::CsvStringModel do
     end
 
     describe "class" do
+      describe "::custom_check_options" do
+        subject { described_class.custom_check_options(options) }
+
+        context "with invalid :type Option" do
+          let(:options) { { type: Object } }
+
+          it "does nothing" do
+            expect { subject }.to_not raise_error
+          end
+
+          context "with validate_type: true" do
+            let(:options) { super().merge(validate_type: true) }
+
+            it "raises exception" do
+              expect { subject }.to raise_error("with :validate_type, :type must be Boolean, Integer, Float, Date, DateTime")
+            end
+          end
+        end
+      end
+
       describe "::add_type_validation" do
         let(:klass) { Class.new(described_class) }
         subject { klass.add_type_validation :string1, options }
-
 
         described_class::PARSE_VALIDATION_CLASSES.each do |type|
           context "with #{type} type" do
@@ -162,13 +181,6 @@ describe CsvRowModel::Import::CsvStringModel do
               expect(validators.size).to eql 1
               expect(validators.first.class.to_s).to eql "#{type}FormatValidator"
             end
-          end
-        end
-
-        context "with no type" do
-          subject { klass.add_type_validation :string1, validate_type: true }
-          it "raises exception" do
-            expect { subject }.to raise_error(ArgumentError)
           end
         end
 

--- a/spec/csv_row_model/concerns/import/represents_spec.rb
+++ b/spec/csv_row_model/concerns/import/represents_spec.rb
@@ -164,7 +164,7 @@ describe CsvRowModel::Import::Represents do
       let(:options) { {} }
 
       it "calls the underlying methods" do
-        expect(CsvRowModel::Import::Representation).to receive(:check_options).with(options)
+        expect(klass).to receive(:check_options).with(CsvRowModel::Import::Representation, options).once.and_call_original
         expect(CsvRowModel::Import::Representation).to receive(:define_lambda_method).with(klass, :test_model).and_yield
         subject
       end

--- a/spec/csv_row_model/concerns/model/attributes_spec.rb
+++ b/spec/csv_row_model/concerns/model/attributes_spec.rb
@@ -40,11 +40,21 @@ describe CsvRowModel::Model::Attributes do
       let(:klass) { Class.new { include CsvRowModel::Model } }
 
       describe "::column" do
+        subject { klass.send(:column, :blah) }
+
+        it "calls ::check_options with the args" do
+          expect(klass).to receive(:check_options).with(CsvRowModel::Model::Header,
+                                                        CsvRowModel::Import::CsvStringModel::Model,
+                                                        CsvRowModel::Import::Attribute,
+                                                        {}).once.and_call_original
+          subject
+        end
+
         context "with invalid option" do
           subject { klass.send(:column, :blah, invalid_option: true) }
 
           it "raises error" do
-            expect { subject }.to raise_error(ArgumentError)
+            expect { subject }.to raise_error("Invalid option(s): [:invalid_option]")
           end
         end
       end

--- a/spec/csv_row_model/concerns/model/dynamic_columns_spec.rb
+++ b/spec/csv_row_model/concerns/model/dynamic_columns_spec.rb
@@ -16,6 +16,24 @@ describe CsvRowModel::Model::DynamicColumns do
   end
 
   describe "class" do
+    describe "::dynamic_column" do
+      subject { row_model_class.send(:dynamic_column, :blah, options) }
+      let(:options) { { header_models_context_key: :context_key } }
+
+      it "works" do
+        expect(row_model_class).to receive(:check_options).with(CsvRowModel::Model::DynamicColumnHeader, options).once.and_call_original
+        expect { subject }.to_not raise_error
+      end
+
+      context "with invalid option" do
+        let(:options) { { invalid_option: true }}
+
+        it "raises exception" do
+          expect { subject }.to raise_error("Invalid option(s): [:invalid_option]")
+        end
+      end
+    end
+
     describe "::dynamic_column_index" do
       subject { row_model_class.dynamic_column_index(:skills) }
 

--- a/spec/csv_row_model/internal/import/attribute_spec.rb
+++ b/spec/csv_row_model/internal/import/attribute_spec.rb
@@ -105,14 +105,6 @@ describe CsvRowModel::Import::Attribute do
           end
         end
 
-        context "of Object (invalid)" do
-          let(:options) { { type: Object } }
-
-          it "raises exception" do
-            expect { subject }.to raise_error(ArgumentError)
-          end
-        end
-
         context "with nil source_value" do
           let(:source_value) { nil }
 
@@ -141,14 +133,6 @@ describe CsvRowModel::Import::Attribute do
           it "returns the other attribute" do
             expect(subject).to eql "original_string2"
           end
-        end
-      end
-
-      context "with :type and :parse option" do
-        let(:options) { { type: Date, parse: ->(s) { "haha" } } }
-
-        it "raises exception" do
-          expect { subject }.to raise_error('Use :parse OR :type option, but not both for: string1')
         end
       end
     end
@@ -228,6 +212,28 @@ describe CsvRowModel::Import::Attribute do
         it "returns the formatted_value and default_value" do
           expect(instance).to receive(:default?).once.and_return(true)
           expect(subject).to eql ["1.01", "default"]
+        end
+      end
+    end
+  end
+
+  describe "class" do
+    describe "::custom_check_options" do
+      subject { described_class.custom_check_options(options) }
+
+      context "with invalid :type Option" do
+        let(:options) { { type: Object } }
+
+        it "raises exception" do
+          expect { subject }.to raise_error(":type must be Boolean, String, Integer, Float, DateTime, Date")
+        end
+      end
+
+      context "with :type and :parse option" do
+        let(:options) { { type: Date, parse: ->(s) { "haha" } } }
+
+        it "raises exception" do
+          expect { subject }.to raise_error('Use :parse OR :type option, but not both')
         end
       end
     end


### PR DESCRIPTION
always check options using `check_options klass1, klass2, ..., options` interface, where `klass1` contains validation logic for the options `klass1` uses---basically puts "using" and "validating" options logic together.

also does the checks when adding the options. ie.

``` ruby
column :name, options # validation _always_ happens here

ImportRowModel.new(row).attributes # previously, validation sometimes happens here
```
